### PR TITLE
[Feature/1] Create Notion Domain

### DIFF
--- a/docs/[Baekjoon] 2042 구간 합 구하기.md
+++ b/docs/[Baekjoon] 2042 구간 합 구하기.md
@@ -1,0 +1,132 @@
+# [Baekjoon] 2042 구간 합 구하기
+## 설명
+
+어떤 **N개의 수**가 주어져 있다. 그런데 중간에 수의 변경이 빈번히 일어나고 그 중간에 **어떤 부분의 합을 구하려 한다**. 만약에 **1,2,3,4,5 라는 수가 있고, 3번째 수를 6으로 바꾸고 2번째부터 5번째까지 합을 구하라고 한다면 17**을 출력하면 되는 것이다. 그리고 그 상태에서 다섯 번째 수를 2로 바꾸고 3번째부터 5번째까지 합을 구하라고 한다면 12가 될 것이다.
+
+## 입력
+
+첫째 줄에 수의 개수 **N**(1 ≤ N ≤ 1,000,000)과 M(1 ≤ M ≤ 10,000), K(1 ≤ K ≤ 10,000) 가 주어진다. **M은 수의 변경이 일어나는 횟수이고, K는 구간의 합을 구하는 횟수**이다. 그리고 둘째 줄부터 N+1번째 줄까지 N개의 수가 주어진다. 그리고 N+2번째 줄부터 N+M+K+1번째 줄까지 세 개의 정수 a, b, c가 주어지는데, a가 1인 경우 b(1 ≤ b ≤ N)번째 수를 c로 바꾸고 a가 2인 경우에는 b(1 ≤ b ≤ N)번째 수부터 c(b ≤ c ≤ N)번째 수까지의 합을 구하여 출력하면 된다.
+
+입력으로 주어지는 모든 수는 -2^63보다 크거나 같고, 2^63-1보다 작거나 같은 정수이다.
+
+## 출력
+
+첫째 줄부터 K줄에 걸쳐 구한 구간의 합을 출력한다. 단, 정답은 -2^63보다 크거나 같고, 2^63-1보다 작거나 같은 정수이다.
+
+### 예시 입력
+
+### 예시 출력
+
+```jsx
+5 2 2
+1
+2
+3
+4
+5
+1 3 6
+2 2 5
+1 5 2
+2 3 5
+```
+
+```jsx
+17
+12
+```
+
+## 풀이 과정
+
+시간 복잡도를 생각하지 않고 풀이를 진행해봅시다. 
+
+N개의 수가 주어져 있고 우리는 어떤 구간의 합을 구하면 되는 간단한 문제입니다. 
+
+예를 들어, 문제에 나와있듯이 1, 2, 3, 4, 5라는 숫자가 존재하고 여기서 2~5 사이의 값을 더한다고 가정해봅시다. 
+
+```java
+int [] arr = new int [] {1,2,3,4,5};
+int sum = 0;
+for(int i = 1; i < 5 ; i++) {
+	sum += arr[i];
+}
+```
+
+N개의 수를 K번 탐색해야 하니 시간 복잡도는 O(NK)가 될 것입니다. (하지만 이는 1,000,000 * 10,000 하게 되어 시간 초과가 발생합니다) 
+
+우리는 세그먼트 트리를 활용해야 합니다. 
+
+### **세그먼트 트리란?**
+
+> 이진 트리의 형태 중 하나이며 빠르게 특정 구간의 합을 구할 수 있다는 특징이 있다.
+> 
+
+![Untitled](%5BBaekjoon%5D%202042%20%E1%84%80%E1%85%AE%E1%84%80%E1%85%A1%E1%86%AB%20%E1%84%92%E1%85%A1%E1%86%B8%20%E1%84%80%E1%85%AE%E1%84%92%E1%85%A1%E1%84%80%E1%85%B5%20a5f82f91b68d4c4ea3e05e64ac410690/Untitled.png)
+
+위 그림은 [2, 6, 4, -3, 5, -1, 6, 10] 에 대한 세그먼트 트리입니다. 
+
+리프 노트는 각각의 원소를 의미하고 리프 노드가 아닌 노드는 구간의 합을 의미합니다. 
+
+이를 통해 어떻게 합을 빠르게 구할 수 있을까요?
+
+예를 들어, 인덱스 2에서 5사이의 값을 찾고 싶다고 가정해봅시다. 
+
+우리는 [0-3] + [4-5] 를 통해 빠르게 그 값을 도출해 낼 수 있습니다. 
+
+(이전에 언급했듯 N번 반복해서 구할 수 있지만 그 값이 커진다면 시간 초과가 날 것 입니다)
+
+**세그먼트 트리는 어떻게 구현할까요?**
+
+```java
+public class SegmentTree {
+
+		// 배열로 구현 
+    private long[] tree;
+
+    public SegmentTree(int n) {
+				// 높이는 log2(n) 이 때 무조건 올림을 해주어야 합니다.  
+        double height = Math.ceil(Math.log(n) / Math.log(2)) + 1;
+				// 2 ^ (height)
+        long count = Math.round(Math.pow(2, height));
+        tree = new long[count];
+    }
+
+    long init(long[] arr, int node, int start, int end) {
+        if (start == end) {
+            return tree[node] = arr[start];
+        } else {
+						// 재귀로 진행합니다.
+						// 자식 노드는 현재 노드의 2x, 2x+1 입니다.
+            return tree[node] = init(arr, node * 2, start, (start + end) / 2)
+	+ init(arr, node * 2 + 1, (start + end) / 2 + 1, end);
+        }
+    }
+
+    long sum(int node, int start, int end, int left, int right) {
+				// 범위를 벗어났다면 0을 반환합니다.
+        if (end < left || right < start) {
+            return 0;
+				// 범위 사이에 있다면 우선 해당 노드의 값은 반환합니다.
+        } else if (left <= start && end <= right) {
+            return tree[node];
+				// 범위 외에 있는 값들을 재귀로 찾습니다. 
+        } else {
+            return sum(node * 2, start, (start + end) / 2, left, right)
+	+ sum(node * 2 + 1, (start + end) / 2 + 1, end, left, right);
+        }
+    }
+
+    long update(int node, int start, int end, int index, long changeValue) {
+        if (index < start || end < index) {
+            return tree[node];
+				// 리프 노드에 도착한다면 값을 바꿔줍니다.
+        } else if (start == index && end == index) {
+            return tree[node] = changeValue;
+        } else {
+				// 바꾼 값으로 구간 합을 대체합니다.
+            return tree[node] =
+	update(node * 2, start, (start + end) / 2, index, changeValue) +
+	    update(node * 2 + 1, (start + end) / 2 + 1, end, index, changeValue);
+        }
+    }
+}
+```

--- a/src/main/java/com/example/sn2t/notion/application/BlockService.java
+++ b/src/main/java/com/example/sn2t/notion/application/BlockService.java
@@ -1,0 +1,34 @@
+package com.example.sn2t.notion.application;
+
+import static com.example.sn2t.notion.domain.notion.NotionProperties.*;
+
+import com.example.sn2t.notion.domain.Page;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class BlockService {
+
+    private final WebClient webClient;
+
+    public BlockService() {
+        this.webClient = WebClient.builder()
+            .baseUrl(blockBaseUrl.get())
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    public String retrieveBlockChildren(String pageId, String secretKey) {
+        Page page = webClient.get()
+            .uri(pageId + "/children?page_size=100")
+            .header("Authorization", "Bearer " + secretKey)
+            .header("Notion-Version", "2022-06-28")
+            .retrieve()
+            .bodyToMono(Page.class)
+            .block();
+
+        return page.toMarkdown();
+    }
+}

--- a/src/main/java/com/example/sn2t/notion/application/DatabaseService.java
+++ b/src/main/java/com/example/sn2t/notion/application/DatabaseService.java
@@ -20,7 +20,7 @@ public class DatabaseService {
 
     public DatabaseService() {
         this.webClient = WebClient.builder()
-            .baseUrl(baseUrl.get())
+            .baseUrl(databaseBaseUrl.get())
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .build();
     }

--- a/src/main/java/com/example/sn2t/notion/application/DatabaseService.java
+++ b/src/main/java/com/example/sn2t/notion/application/DatabaseService.java
@@ -1,0 +1,63 @@
+package com.example.sn2t.notion.application;
+
+import static com.example.sn2t.notion.domain.notion.NotionProperties.*;
+
+import com.example.sn2t.notion.presentation.dto.NotionConnectRequest;
+import com.example.sn2t.notion.presentation.dto.RetrievePageIdsRequest;
+import com.example.sn2t.notion.presentation.dto.RetrievePageIdsResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class DatabaseService {
+
+    private final WebClient webClient;
+
+    public DatabaseService() {
+        this.webClient = WebClient.builder()
+            .baseUrl(baseUrl.get())
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    private <T> T query(String databaseId, String secretKey, Class<T> responseType) {
+        return webClient.post()
+            .uri(databaseId + "/query")
+            .header("Authorization", "Bearer " + secretKey)
+            .header("Notion-Version", "2022-06-28")
+            .retrieve()
+            .bodyToMono(responseType)
+            .block();
+    }
+
+    public boolean isConnected(NotionConnectRequest request) {
+        try {
+            query(request.databaseId(), request.secretKey(), String.class);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+
+    public List<String> retrievePageIds(RetrievePageIdsRequest request) {
+        String secretKey = "secret_DttkpH5a7QYGkZ1Fc7NkooLzTAj5LeXUfjbc8f1LFxY";
+        RetrievePageIdsResponse response = query(
+            request.databaseId(),
+            secretKey,
+            RetrievePageIdsResponse.class
+        );
+
+        if (response != null && response.getResults() != null) {
+            return response.getResults().stream()
+	.map(RetrievePageIdsResponse.Result::getId)
+	.collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/example/sn2t/notion/application/NotionService.java
+++ b/src/main/java/com/example/sn2t/notion/application/NotionService.java
@@ -1,65 +1,8 @@
 package com.example.sn2t.notion.application;
 
-import com.example.sn2t.notion.presentation.dto.NotionConnectRequest;
-import com.example.sn2t.notion.presentation.dto.RetrievePageIdsRequest;
-import com.example.sn2t.notion.presentation.dto.RetrievePageIdsResponse;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 public class NotionService {
 
-    private final String notionBaseUrl = "https://api.notion.com/v1/databases/";
-    private final WebClient webClient;
-
-    public NotionService() {
-        this.webClient = WebClient.builder()
-            .baseUrl(notionBaseUrl)
-            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .build();
-    }
-
-    public boolean isConnected(NotionConnectRequest request) {
-        try {
-            webClient.post()
-	.uri(request.databaseId() + "/query")
-	.header("Authorization", "Bearer " + request.secretKey())
-	.header("Notion-Version", "2022-06-28")
-	.retrieve()
-	.bodyToMono(String.class)
-	.block();
-        } catch (Exception e) {
-            return false;
-        }
-        return true;
-    }
-
-    public List<String> retrievePageIds(RetrievePageIdsRequest request) {
-        WebClient webClient = WebClient.builder()
-            .baseUrl(notionBaseUrl)
-            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .build();
-
-        RetrievePageIdsResponse response = webClient.post()
-            .uri(request.databaseId() + "/query")
-            .header("Authorization",
-	"Bearer " + "secret_DttkpH5a7QYGkZ1Fc7NkooLzTAj5LeXUfjbc8f1LFxY")
-            .header("Notion-Version", "2022-06-28")
-            .retrieve()
-            .bodyToMono(RetrievePageIdsResponse.class)
-            .block();
-
-        if (response != null && response.getResults() != null) {
-            return response.getResults().stream()
-	.map(RetrievePageIdsResponse.Result::getId)
-	.collect(Collectors.toList());
-        } else {
-            return Collections.emptyList();
-        }
-    }
 }

--- a/src/main/java/com/example/sn2t/notion/domain/Page.java
+++ b/src/main/java/com/example/sn2t/notion/domain/Page.java
@@ -1,0 +1,26 @@
+package com.example.sn2t.notion.domain;
+
+import com.example.sn2t.notion.domain.block.Block;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Page {
+
+    private List<Block> results;
+
+    public String toMarkdown() {
+        StringBuilder markdown = new StringBuilder();
+
+        for (Block block : this.results) {
+            markdown.append(block.toMarkdown());
+        }
+
+        return markdown.toString();
+    }
+}

--- a/src/main/java/com/example/sn2t/notion/domain/block/Block.java
+++ b/src/main/java/com/example/sn2t/notion/domain/block/Block.java
@@ -1,0 +1,56 @@
+package com.example.sn2t.notion.domain.block;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Block {
+
+    private String id;
+    private String type;
+    @JsonAlias({"heading_1", "heading_2", "heading_3", "paragraph", "code"})
+    private Content content;
+
+    public String toMarkdown() {
+        String markdownPrefix = getMarkdownPrefix(type);
+        String markdownSuffix = getMarkdownSuffix(type);
+        return markdownPrefix + (content != null ? content.toMarkdown() : "") + markdownSuffix;
+    }
+
+    private String getMarkdownPrefix(String type) {
+        if (type == null) {
+            return "";
+        }
+
+        switch (type) {
+            case "heading_1":
+                return "# ";
+            case "heading_2":
+                return "## ";
+            case "heading_3":
+                return "### ";
+            case "code":
+                return "```java\n";
+            default:
+                return "";
+        }
+    }
+
+    private String getMarkdownSuffix(String type) {
+        if (type == null) {
+            return "";
+        }
+
+        switch (type) {
+            case "code":
+                return "\n```\n";
+            default:
+                return "\n";
+        }
+    }
+}

--- a/src/main/java/com/example/sn2t/notion/domain/block/Content.java
+++ b/src/main/java/com/example/sn2t/notion/domain/block/Content.java
@@ -1,0 +1,31 @@
+package com.example.sn2t.notion.domain.block;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Content {
+
+    @JsonProperty("rich_text")
+    private List<RichText> texts;
+
+    public String toMarkdown() {
+        StringBuilder markdown = new StringBuilder();
+
+        for (RichText richText : this.texts) {
+            markdown.append(richText.toMarkdown());
+        }
+
+        if (markdown.length() > 0 && markdown.toString().startsWith("```")) {
+            markdown.append("\n```");
+        }
+
+        return markdown.toString();
+    }
+}

--- a/src/main/java/com/example/sn2t/notion/domain/block/RichText.java
+++ b/src/main/java/com/example/sn2t/notion/domain/block/RichText.java
@@ -1,0 +1,54 @@
+package com.example.sn2t.notion.domain.block;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RichText {
+
+    private String type;
+
+    @JsonProperty("plain_text")
+    private String plainText;
+    private Annotations annotations;
+
+    public String toMarkdown() {
+        String text = plainText;
+
+        if (annotations.isBold()) {
+            text = "**" + text + "**";
+        }
+        if (annotations.isItalic()) {
+            text = "*" + text + "*";
+        }
+        if (annotations.isStrikethrough()) {
+            text = "~~" + text + "~~";
+        }
+        if (annotations.isUnderline()) {
+            text = "<u>" + text + "</u>";
+        }
+        if (annotations.isCode()) {
+            text = "`" + text + "`";
+        }
+
+        return text;
+    }
+
+    @Data
+    static class Annotations {
+
+        private boolean bold;
+        private boolean italic;
+        private boolean strikethrough;
+        private boolean underline;
+        private boolean code;
+        private String color;
+    }
+}
+

--- a/src/main/java/com/example/sn2t/notion/domain/notion/NotionProperties.java
+++ b/src/main/java/com/example/sn2t/notion/domain/notion/NotionProperties.java
@@ -1,0 +1,15 @@
+package com.example.sn2t.notion.domain.notion;
+
+public enum NotionProperties {
+    baseUrl("https://api.notion.com/v1/databases/");
+
+    NotionProperties(String description) {
+        this.description = description;
+    }
+
+    private String description;
+
+    public String get() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/sn2t/notion/domain/notion/NotionProperties.java
+++ b/src/main/java/com/example/sn2t/notion/domain/notion/NotionProperties.java
@@ -1,7 +1,8 @@
 package com.example.sn2t.notion.domain.notion;
 
 public enum NotionProperties {
-    baseUrl("https://api.notion.com/v1/databases/");
+    databaseBaseUrl("https://api.notion.com/v1/databases/"),
+    blockBaseUrl("https://api.notion.com/v1/blocks/");
 
     NotionProperties(String description) {
         this.description = description;

--- a/src/main/java/com/example/sn2t/notion/presentation/dto/RetrievePageIdsResponse.java
+++ b/src/main/java/com/example/sn2t/notion/presentation/dto/RetrievePageIdsResponse.java
@@ -14,5 +14,4 @@ public class RetrievePageIdsResponse {
 
         private String id;
     }
-
 }

--- a/src/test/java/com/example/sn2t/notion/DatabaseServiceTest.java
+++ b/src/test/java/com/example/sn2t/notion/DatabaseServiceTest.java
@@ -1,21 +1,19 @@
 package com.example.sn2t.notion;
 
-import com.example.sn2t.notion.application.NotionService;
+import com.example.sn2t.notion.application.DatabaseService;
 import com.example.sn2t.notion.presentation.dto.NotionConnectRequest;
 import com.example.sn2t.notion.presentation.dto.RetrievePageIdsRequest;
 import java.util.List;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
-public class NotionServiceTest {
+@SpringBootTest
+public class DatabaseServiceTest {
 
-    private NotionService notionService;
-
-    @BeforeEach
-    void setUp() {
-        notionService = new NotionService();
-    }
+    @Autowired
+    private DatabaseService databaseService;
 
     @Test
     void Notion_연결이_되었다면_true를_반환한다() {
@@ -25,10 +23,10 @@ public class NotionServiceTest {
 
         // when
         NotionConnectRequest request = new NotionConnectRequest(databaseId, secretKey);
-        notionService.isConnected(request);
+        databaseService.isConnected(request);
 
         // given
-        Assertions.assertThat(notionService.isConnected(request)).isTrue();
+        Assertions.assertThat(databaseService.isConnected(request)).isTrue();
     }
 
     @Test
@@ -40,10 +38,10 @@ public class NotionServiceTest {
         NotionConnectRequest request = new NotionConnectRequest(wrongDatabaseId, secretKey);
 
         // when
-        notionService.isConnected(request);
+        databaseService.isConnected(request);
 
         // then
-        Assertions.assertThat(notionService.isConnected(request)).isFalse();
+        Assertions.assertThat(databaseService.isConnected(request)).isFalse();
     }
 
     @Test
@@ -53,9 +51,10 @@ public class NotionServiceTest {
         RetrievePageIdsRequest request = new RetrievePageIdsRequest(databaseId);
 
         // when
-        List<String> pageIds = notionService.retrievePageIds(request);
+        List<String> pageIds = databaseService.retrievePageIds(request);
 
         // then
         Assertions.assertThat(pageIds).hasSize(2);
     }
+
 }

--- a/src/test/java/com/example/sn2t/notion/application/BlockServiceTest.java
+++ b/src/test/java/com/example/sn2t/notion/application/BlockServiceTest.java
@@ -1,0 +1,30 @@
+package com.example.sn2t.notion.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BlockServiceTest {
+
+    @Autowired
+    private BlockService blockService;
+
+    @Test
+    void 페이지_내용을_마크다운_형식으로_조회한다() {
+        // given
+        String pageId = "a5f82f91-b68d-4c4e-a3e0-5e64ac410690";
+        String secretKey = "secret_DttkpH5a7QYGkZ1Fc7NkooLzTAj5LeXUfjbc8f1LFxY";
+
+        // when
+        String markdown = blockService.retrieveBlockChildren(pageId, secretKey);
+
+        // then
+        Assertions.assertThat(markdown).isNotNull();
+        Assertions.assertThat(markdown).isNotBlank();
+    }
+
+}


### PR DESCRIPTION
## Description
**Issue** #1 
원하는 값을 파싱할 수 있도록 DTO 클래스와 관련된 도메인 객체를 생성한다

## Details
Retrieve a block children 를 사용하면 Page 내의 Content를 가져올 수 있습니다. 
하지만 각 한 줄 마다 block으로 분리되며, 마크다운 기호들은 같이 조회되지 않아 prefix 혹은 suffix로 해당 마크다운을 붙여줘야 합니다.

코드 예시는 다음과 같습니다.
```java
    private String getMarkdownPrefix(String type) {
        if (type == null) {
            return "";
        }

        switch (type) {
            case "heading_1":
                return "# ";
            case "heading_2":
                return "## ";
            case "heading_3":
                return "### ";
            case "code":
                return "```java\n";
            default:
                return "";
        }
    }

    private String getMarkdownSuffix(String type) {
        if (type == null) {
            return "";
        }

        switch (type) {
            case "code":
                return "\n```\n";
            default:
                return "\n";
        }
    }

```

추가적으로 Domain 클래스 뿐만 아니라 Service, Test 클래스 까지 작성을 같이 진행하였습니다.

## More (Optional)
WebClient를 통해 JSON 값을 자바 클래스로 변환하고 있습니다. 
```java
public String retrieveBlockChildren(String pageId, String secretKey) {
        Page page = webClient.get()
            .uri(pageId + "/children?page_size=100")
            .header("Authorization", "Bearer " + secretKey)
            .header("Notion-Version", "2022-06-28")
            .retrieve()
            .bodyToMono(Page.class)
            .block();

        return page.toMarkdown();
    }
``` 

중요한건 변환 시 기본 생성자, Getter, Setter가 존재해야 합니다. 
`@Data` 로는 기본 생성자가 생성되지 않으며 Getter, Setter도 문제가 생길 수 있습니다. 

따라서 다음과 같은 Annotation을 Parsing 클래스에 전부 붙여주었습니다.
```java
@Getter
@Setter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Page {
```