### PR TITLE
[Feature/3] status 관련 기능 추가

### DIFF
--- a/src/main/java/com/example/sn2t/notion/application/PageService.java
+++ b/src/main/java/com/example/sn2t/notion/application/PageService.java
@@ -1,0 +1,47 @@
+package com.example.sn2t.notion.application;
+
+
+import static com.example.sn2t.notion.domain.notion.NotionProperties.*;
+
+import com.example.sn2t.notion.domain.notion.NotionProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class PageService {
+
+    private final WebClient webClient;
+
+    public PageService() {
+        this.webClient = WebClient.builder()
+            .baseUrl(pageBaseUrl.get())
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    /*
+     * to는 바꾸고자 하는 상태로, "UNCOMPLETED", "UPLOADING" 또는 "COMPLETED"가 될 수 있습니다.
+     */
+    public void updateStatusProperties(String pageId, String secretKey, String to) {
+        String jsonBody = "{\n"
+            + "  \"properties\": {\n"
+            + "    \"status\": {\n"
+            + "      \"select\": {\n"
+            + "        \"name\": \"" + to + "\"\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}\n";
+
+        webClient.patch()
+            .uri(pageId)
+            .header("Authorization", "Bearer " + secretKey)
+            .header("Notion-Version", "2022-06-28")
+            .bodyValue(jsonBody)
+            .retrieve()
+            .toBodilessEntity()
+            .block();
+    }
+}

--- a/src/main/java/com/example/sn2t/notion/domain/notion/NotionProperties.java
+++ b/src/main/java/com/example/sn2t/notion/domain/notion/NotionProperties.java
@@ -2,7 +2,8 @@ package com.example.sn2t.notion.domain.notion;
 
 public enum NotionProperties {
     databaseBaseUrl("https://api.notion.com/v1/databases/"),
-    blockBaseUrl("https://api.notion.com/v1/blocks/");
+    blockBaseUrl("https://api.notion.com/v1/blocks/"),
+    pageBaseUrl("https://api.notion.com/v1/pages/");
 
     NotionProperties(String description) {
         this.description = description;


### PR DESCRIPTION
## Description
페이지의 Status와 관련된 기능을 추가한다

## Details
기존 `query()` 를 리팩토링 하여 확장성을 추가하였습니다.
```java
    private <T> T query(String databaseId, String secretKey, Class<T> responseType,
        String jsonBody) {
        return webClient.post()
            .uri(databaseId + "/query")
            .header("Authorization", "Bearer " + secretKey)
            .header("Notion-Version", "2022-06-28")
            .bodyValue(jsonBody)
            .retrieve()
            .bodyToMono(responseType)
            .block();
    }
```
이제 jsonBody에 여러 요청을 String 형태로 주입할 수 있습니다.

## More (Optional)
속성을 업데이트 하는 건 Status에 국한되지 않고 다른 여러 곳에서 재사용될 수 있으니, 후에 이를 범용성 좋게 리팩토링 할 필요가 있습니다.
```java
    public void updateStatusProperties(String pageId, String secretKey, String to) {
        String jsonBody = "{\n"
            + "  \"properties\": {\n"
            + "    \"status\": {\n"
            + "      \"select\": {\n"
            + "        \"name\": \"" + to + "\"\n"
            + "      }\n"
            + "    }\n"
            + "  }\n"
            + "}\n";

        webClient.patch()
            .uri(pageId)
            .header("Authorization", "Bearer " + secretKey)
            .header("Notion-Version", "2022-06-28")
            .bodyValue(jsonBody)
            .retrieve()
            .toBodilessEntity()
            .block();
    }
```